### PR TITLE
Scoped CSS for Color highlighting

### DIFF
--- a/sass/_component_autodoc.scss
+++ b/sass/_component_autodoc.scss
@@ -5,14 +5,14 @@ dl.class {
 }
 
 // colour highlighting for the classes and methods
-
 html.no-js {
     div.row {
         dl.class {
-            &  span.sig-prename.descclassname {
+             span.sig-prename.descclassname {
                 color: $black;
-            }  
-            & > dt {
+            }
+
+            > dt {
                 font-weight: 700;
                 display: table;
                 margin: 0.25rem 0;
@@ -24,10 +24,10 @@ html.no-js {
                 padding: 0.25rem;
                 position: relative;
             }
+
             &:not(.field-list) > dt {
                 display: table;
                 margin-bottom: 0.25rem;
-                border: none;
                 border-left: 3px solid $gray-500;
                 background: $gray-100;
                 color: $gray-600;

--- a/sass/_component_autodoc.scss
+++ b/sass/_component_autodoc.scss
@@ -4,36 +4,26 @@ dl.class {
   }
 }
 
-// colour highlighting for the classes
-dl.class {
-    span.sig-prename.descclassname {
-        color: $black;
-    }    
-}
-
+// colour highlighting for the classes and methods
 
 html.no-js {
     div.row {
-        dl.class > dt {
-            font-weight: 700;
-            display: table;
-            margin: 0.25rem 0;
-            font-size: 90%;
-            line-height: normal;
-            background: $gray-100;
-            color: $indigo;
-            border-top: 3px solid $indigo;
-            padding: 0.25rem;
-            position: relative;
-        }
-    }
-}
-
-// colour highlighting for the methods
-
-html.no-js{
-    div.row{
         dl.class {
+            &  span.sig-prename.descclassname {
+                color: $black;
+            }  
+            & > dt {
+                font-weight: 700;
+                display: table;
+                margin: 0.25rem 0;
+                font-size: 90%;
+                line-height: normal;
+                background: $gray-100;
+                color: $indigo;
+                border-top: 3px solid $indigo;
+                padding: 0.25rem;
+                position: relative;
+            }
             &:not(.field-list) > dt {
                 display: table;
                 margin-bottom: 0.25rem;
@@ -42,6 +32,7 @@ html.no-js{
                 background: $gray-100;
                 color: $gray-600;
             }
-        }        
+        } 
     }
 }
+

--- a/sass/_component_autodoc.scss
+++ b/sass/_component_autodoc.scss
@@ -8,7 +8,7 @@ dl.class {
 html.no-js {
     div.row {
         dl.class {
-             span.sig-prename.descclassname {
+             .sig-prename {
                 color: $black;
             }
 

--- a/sass/_component_autodoc.scss
+++ b/sass/_component_autodoc.scss
@@ -1,3 +1,32 @@
 dd {
     margin: 0 0 12px 24px;
 }
+
+// colour highlighting for the classes
+
+span.sig-prename.descclassname {
+    color: #000;
+}
+
+html.no-js .row dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple)>dt {
+    font-weight: 700;
+    display: table;
+    margin: 6px 0;
+    font-size: 90%;
+    line-height: normal;
+    background: #f2f2f2;
+    color: #2e1f5e;
+    border-top: 3px solid #2e1f5e;
+    padding: 6px;
+    position: relative;
+}
+
+// colour highlighting for the methods
+    
+html.no-js .row dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) dl:not(.field-list)>dt {
+    margin-bottom: 6px;
+    border: none;
+    border-left: 3px solid #ccc;
+    background: #f0f0f0;
+    color: #555;
+}

--- a/sass/_component_autodoc.scss
+++ b/sass/_component_autodoc.scss
@@ -1,0 +1,3 @@
+dd {
+    margin: 0 0 12px 24px;
+}

--- a/sass/_component_autodoc.scss
+++ b/sass/_component_autodoc.scss
@@ -1,38 +1,31 @@
 dl.class {
-  .sig-object + dd {
-    margin: 0 0 0.5rem 1.5rem;
-  }
-}
+    .sig-object + dd {
+        margin: 0 0 0.5rem 1.5rem;
+    }
 
-// colour highlighting for the classes and methods
-html.no-js {
-    div.row {
-        dl.class {
-             .sig-prename {
-                color: $black;
-            }
+  // colour highlighting for the classes and methods
+    .sig-prename {
+        color: $black;
+    }
 
-            > dt {
-                font-weight: 700;
-                display: table;
-                margin: 0.25rem 0;
-                font-size: 90%;
-                line-height: normal;
-                background: $gray-100;
-                color: $indigo;
-                border-top: 3px solid $indigo;
-                padding: 0.25rem;
-                position: relative;
-            }
+    > dt {
+        font-weight: 700;
+        display: table;
+        margin: 0.25rem 0;
+        font-size: 90%;
+        line-height: normal;
+        background: $gray-100;
+        color: $indigo;
+        border-top: 3px solid $indigo;
+        padding: 0.25rem;
+        position: relative;
+    }
 
-            &:not(.field-list) > dt {
-                display: table;
-                margin-bottom: 0.25rem;
-                border-left: 3px solid $gray-500;
-                background: $gray-100;
-                color: $gray-600;
-            }
-        } 
+    &:not(.field-list) > dt {
+        display: table;
+        margin-bottom: 0.25rem;
+        border-left: 3px solid $gray-500;
+        background: $gray-100;
+        color: $gray-600;
     }
 }
-

--- a/sass/_component_autodoc.scss
+++ b/sass/_component_autodoc.scss
@@ -3,3 +3,45 @@ dl.class {
     margin: 0 0 0.5rem 1.5rem;
   }
 }
+
+// colour highlighting for the classes
+dl.class {
+    span.sig-prename.descclassname {
+        color: $black;
+    }    
+}
+
+
+html.no-js {
+    div.row {
+        dl.class > dt {
+            font-weight: 700;
+            display: table;
+            margin: 0.25rem 0;
+            font-size: 90%;
+            line-height: normal;
+            background: $gray-100;
+            color: $indigo;
+            border-top: 3px solid $indigo;
+            padding: 0.25rem;
+            position: relative;
+        }
+    }
+}
+
+// colour highlighting for the methods
+
+html.no-js{
+    div.row{
+        dl.class {
+            &:not(.field-list) > dt {
+                display: table;
+                margin-bottom: 0.25rem;
+                border: none;
+                border-left: 3px solid $gray-500;
+                background: $gray-100;
+                color: $gray-600;
+            }
+        }        
+    }
+}

--- a/sass/theme.scss
+++ b/sass/theme.scss
@@ -26,6 +26,7 @@
 @import "component_toc";
 @import "component_version";
 @import "component_versionpicker_fix";
+@import "component_autodoc";
 
 // misc
 @import "layout";


### PR DESCRIPTION
This pull request reference this #231. This is an improvement from #231 due to feedback given by @lb- 

- The changes made scopes the css additions.
- Makes use of color variables from scss/_variable.css
- Cleans up the css to look more better.
- It should be noted the usage of `dl.class > dt` and `dl.class :not(.field-list) >dt`.  The first handles color highlighting for classes; the latter handles for methods. Check comments below for screenshots on this