### PR TITLE
version button problem fixed

### DIFF
--- a/sass/_component_versionpicker_fix.scss
+++ b/sass/_component_versionpicker_fix.scss
@@ -8,13 +8,14 @@ These overrides are necessary to make the version picker work with the Sphinx Wa
   bottom: 50px;
   right: 50px;
   max-width: $modal-sm;
-  height:80vh;
+  max-height: calc(100vh 50px);
   overflow-y: auto;
   background: #1f1d1d;
   z-index: 1050;
 
   &.shift-up .rst-other-versions {
     display: block;
+    height: 80vh;
   }
 
   a {

--- a/sass/_component_versionpicker_fix.scss
+++ b/sass/_component_versionpicker_fix.scss
@@ -8,7 +8,7 @@ These overrides are necessary to make the version picker work with the Sphinx Wa
   bottom: 50px;
   right: 50px;
   max-width: $modal-sm;
-  max-height: calc(100vh - 50px);
+  height:80vh;
   overflow-y: auto;
   background: #1f1d1d;
   z-index: 1050;


### PR DESCRIPTION
We were not able to close version button cause it's close button was hiding on top cause of a little CSS mistake in [sphinx_wagtail_theme/sass/_component_versionpicker_fix.scss](https://github.com/wagtail/sphinx_wagtail_theme/blob/5a42098f0c75843b0f7aab922b9c69994dbf4768/sass/_component_versionpicker_fix.scss#L11) file, but now it is fixed 

This PR solves issue number #247