### PR TITLE
Update release process to make GitHub release

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Checklist:
 -   [ ] `setup.cfg` is updated (see `version`)
 -   [ ] Everything is committed, clean checkout
 -   [ ] `~/.pypirc` has a username and password (token)
--   [ ] Add a git tag and a GitHub release once completed
+-   [ ] Add a git tag at the release commit with the formst `X.Y.Z`
+-   [ ] Create a GitHub release against that tag with the title format `vX.Y.Z`
 
 With an active virtual environment:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Checklist:
 -   [ ] `setup.cfg` is updated (see `version`)
 -   [ ] Everything is committed, clean checkout
 -   [ ] `~/.pypirc` has a username and password (token)
--   [ ] Add a git tag at the release commit with the formst `X.Y.Z`
+-   [ ] Add a git tag at the release commit with the format `X.Y.Z`
 -   [ ] Create a GitHub release against that tag with the title format `vX.Y.Z`
 
 With an active virtual environment:


### PR DESCRIPTION
It was not really clear that a tag and a GitHub release are needed, pull these into discrete items in the checklist.