### PR TITLE
Ensure copy button is always visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   Ensure names in code use monospace fonts (LB (Ben) Johnston)
+-   Ensure code copy button is always visible (LB (Ben) Johnston)
 
 ### Removed
 

--- a/sass/_component_copybutton.scss
+++ b/sass/_component_copybutton.scss
@@ -1,0 +1,5 @@
+// Ensure copy button is always visible
+.pre ~ button.copybtn,
+pre ~ button.copybtn {
+  opacity: 1;
+}

--- a/sass/theme.scss
+++ b/sass/theme.scss
@@ -27,6 +27,7 @@
 @import "component_version";
 @import "component_versionpicker_fix";
 @import "component_autodoc";
+@import "component_copybutton";
 
 // misc
 @import "layout";


### PR DESCRIPTION
- Fixes #242 (I think it makes sense to keep this always visible, it is not obtrusive)
- Builds on dependencies update PR #258
- Using a specific selector so our override works (Sphinx styles are loaded last)

![Screenshot 2023-07-14 at 5 05 30 pm](https://github.com/wagtail/sphinx-wagtail-theme/assets/1396140/a0a98f62-b2b8-4f37-980c-40da1ef25723)
