### PR TITLE
Upgrade all tooling to Python 3.10 & officially drop Python 3.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,17 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: nvm
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v3
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
       - run: npm install
       - run: npm run build
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - run: pip install wheel
       - run: python setup.py bdist_wheel
       - uses: actions/upload-artifact@v1
@@ -35,10 +35,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - run: make setup
       - run: make install-for-development
       - run: make lint-minimal
@@ -51,9 +51,9 @@ jobs:
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Setup Firefox and geckodriver
         uses: ./.github/actions/setup-firefox
       - run: make setup
@@ -71,9 +71,9 @@ jobs:
         with:
           name: bdist-wheel-package
           path: packages
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - run: pip install sphinx
       - run: pip install $(find packages -name "*.whl")
       - name: Assert is importable, show version
@@ -93,7 +93,7 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v2
         with:
           name: static-files

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,6 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.7
+  version: '3.10'
   install:
     - requirements: docs/requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ All notable changes to this project will be documented in this file.
 
 -   Remove Algolia DocSearch meta tags (Thibaud Colas)
 -   Remove jQuery loading by default (LB (Ben) Johnston)
+-   Officially drop support for Pythong 3.7 (LB (Ben) Johnston)
 
 ### Changed
 
 -   Upgrade frontend build dependencies (LB (Ben) Johnston)
+-   Upgrade build tooling to latest GitHub actions and Python 3.10 (LB (Ben) Johnston)
 
 ### Upgrade considerations
 

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ docs: ## Regenerate Sphinx HTML documentation
 
 .PHONY: rtd-docs
 rtd-docs: ## Build the docs like Readthedocs does.
-	python3.7 -m venv "./rtd-venv"
+	python3.10 -m venv "./rtd-venv"
 	./rtd-venv/bin/python -m pip install --upgrade --no-cache-dir pip "setuptools<58.3.0"
 	./rtd-venv/bin/python -m pip install --upgrade --no-cache-dir "mock==1.0.1" "pillow==5.4.1" "alabaster>=0.7,<0.8,!=0.7.5" "commonmark==0.8.1" "recommonmark==0.5.0" "sphinx" "sphinx-rtd-theme" "readthedocs-sphinx-ext<2.2"
 	./rtd-venv/bin/python -m pip install --exists-action=w --no-cache-dir -r docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Sphinx Wagtail theme contains all files required to build a Sphinx extension tha
 -   [Documentation](https://sphinx-wagtail-theme.netlify.app/)
 -   [Security](https://github.com/wagtail/sphinx_wagtail_theme/blob/main/SECURITY.md)
 -   [Changelog](https://github.com/wagtail/sphinx_wagtail_theme/blob/main/CHANGELOG.md)
--   Supports Python > 3.7
+-   Supports Python >= 3.8
 
 ## Installation
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,10 +15,10 @@ classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved :: MIT License
     Intended Audience :: Developers
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: OS Independent
     Topic :: Documentation
     Topic :: Software Development :: Documentation


### PR DESCRIPTION
- Update Readme to clarify 3.8 or greater is supported
- Update package classifiers to have the correct supported Python versions
- Officially drop support for Python 3.7
- Closes #185
- Aligning with Wagtail ecosystem https://github.com/wagtail/wagtail/pull/10676 & https://github.com/wagtail/wagtail/pull/10657