### PR TITLE
fix: fixed import of pkgresources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   Update `favicon` usage to be the new Sphinx variable `favicon_url` & add default favicon (Sahil Jangra)
+-   Avoid using pkgresources module for generating version, replace with use importlib.metadata (Salvo Polizzi)
 
 ### Security
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@
 -   Andy Chosak
 -   Temidayo Azeez
 -   Sahil Jangra
+-   Salvo Polizzi
 
 ## Sphinx Typo3 theme
 

--- a/sphinx_wagtail_theme/__init__.py
+++ b/sphinx_wagtail_theme/__init__.py
@@ -1,10 +1,10 @@
 """Sphinx Wagtail theme"""
 
 import os
-import pkg_resources
+from importlib.metadata import version
 
 
-__version__ = pkg_resources.require("sphinx_wagtail_theme")[0].version
+__version__ = version("sphinx-wagtail-theme")
 __version_full__ = __version__
 
 


### PR DESCRIPTION
Fixes #272: Do not use pkgresources for version anymore because it is deprecated. Instead, use importlib.