### PR TITLE
Fix readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,17 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.12'
+    nodejs: '20'
+  jobs:
+    post_install:
+      - make setup-frontend
+    pre_build:
+      - make frontend
+
 python:
-  version: '3.10'
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Fixes #269

Add missing `build.os` key

https://blog.readthedocs.com/use-build-os-config/

> We are announcing the deprecation of build.image config key in favor of build.os. Read the Docs will start requiring a build.os config key for all projects in order to build documentation successfully. We will start failing builds for projects not using “build.os” in their config file on October 16, 2023.

Also add setup commands to build frontend assets.