### PR TITLE
Toggle to show/hide theme version in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ today_fmt = "%Y-%m-%d %H:%M"
 
 # -- Options for HTML output -------------------------------------------
 html_theme = "sphinx_wagtail_theme"
+html_show_sphinx = True
 html_static_path = []
 html_favicon = "favicon.ico"
 # -- Options for HTMLHelp output ---------------------------------------

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -80,6 +80,15 @@ are valid here. To disable, set to ``None``
 
    html_last_updated_fmt = "%b %d, %Y"
 
+Show Sphinx Theme in Footer
+---------------------------
+
+This built-in Sphinx feature will toggle on or off the "Created using Sphinx Wagtail Theme" in footer. By default it is on. To disable, set to ``False``. Useful if you want to see what version your docs are built with, or want to promote the project.
+
+.. code-block:: python
+
+   html_show_sphinx = False
+
 Custom Fonts & CSS
 ------------------
 

--- a/sphinx_wagtail_theme/footer.html
+++ b/sphinx_wagtail_theme/footer.html
@@ -34,6 +34,10 @@
                     <a href="https://github.com/wagtail/sphinx_wagtail_theme" rel="nofollow" target="_blank">
                         Sphinx Wagtail Theme {{ theme_version|e }}
                     </a>
+                    and
+                    <a href="https://www.sphinx-doc.org/" rel="nofollow" target="_blank">
+                        Sphinx {{ sphinx_version }}
+                    </a>
                 </small>
                 {%- endif %}
             </div>

--- a/sphinx_wagtail_theme/footer.html
+++ b/sphinx_wagtail_theme/footer.html
@@ -12,16 +12,6 @@
                     </ul>
                 </nav>
             {% endif %}
-            <div class="text-center">
-                {%- if last_updated %}
-                <p>Last updated: {{ last_updated|e }}</p>
-                {%- endif %}
-                <p style="display: none">
-                    <a class="text-light" href="https://github.com/wagtail/sphinx_wagtail_theme" rel="nofollow" target="_blank">
-                        Wagtail Sphinx Theme {{ theme_version|e }}
-                    </a>
-                </p>
-            </div>
             {%- if show_copyright %}
             <div class="text-center">
                 {%- if hasdoc('Copyright') %}
@@ -30,6 +20,21 @@
                     <a href="{{ pathto('copyright') }}">&copy; Copyright {{ copyright }}</a>
                 {%- else %}
                     &copy; Copyright {{ copyright }}
+                {%- endif %}
+            </div>
+            {%- endif %}
+            {%- if last_updated or show_sphinx %}
+            <div class="text-center text-white-50 font-italic mt-3">
+                {%- if last_updated %}
+                <small>Last updated: {{ last_updated|e }}</small>
+                {%- endif %}
+                {%- if show_sphinx %}
+                <small>
+                    Created using
+                    <a href="https://github.com/wagtail/sphinx_wagtail_theme" rel="nofollow" target="_blank">
+                        Sphinx Wagtail Theme {{ theme_version|e }}
+                    </a>
+                </small>
                 {%- endif %}
             </div>
             {%- endif %}


### PR DESCRIPTION
Sphinx has a built-in config called `html_show_sphinx` which in nearly all sphinx themes, shows or hides the "Created using Sphinx..." message.

Hooking in to this built-in feature to make it work as expected. Also updated "Customizing" docs respectively.

Reason for this: I was attempting to debug #274 and was gaslighting myself, because the built docs on RTD are NOT using the latest version which has the bug! Having this on our theme docs should help with any future issues.

![image](https://github.com/wagtail/sphinx-wagtail-theme/assets/13453401/e6a2ba00-8ad7-4e05-b8fa-f14c9e065161)

