### PR TITLE
Fix table of contents sidebar overlapping with EthicalAds placement

### DIFF
--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -208,3 +208,19 @@ $grid-gutter-width: 40px;
 // --------------------------------------------------
 
 $medium-width: 768px;
+
+// --------------------------------------------------
+// Z-index
+// https://getbootstrap.com/docs/4.6/layout/overview/#z-index
+// Lower the default z-index values to avoid conflicts with EthicalAds placement
+// on readthedocs.org.
+// See also: https://github.com/readthedocs/ethical-ad-client/pull/196
+// --------------------------------------------------
+
+$zindex-dropdown: 10;
+$zindex-sticky: 20;
+$zindex-fixed: 30;
+$zindex-modal-backdrop: 40;
+$zindex-modal: 50;
+$zindex-popover: 60;
+$zindex-tooltip: 70;


### PR DESCRIPTION
Fixes #293.

## Demo

### Before

https://github.com/user-attachments/assets/f472038f-ee66-4867-9452-0632e0079ab1

### After

https://github.com/user-attachments/assets/75ff9f11-6c1c-44fa-b986-f18b664c8f9e

## Issue recap

EthicalAds placement is done with the following CSS:

```css
[data-ea-style=stickybox].loaded {
    position: fixed;
    bottom: 20px;
    right: 20px;
    z-index: 100;
}
```

Meanwhile, our sidebars use Bootstrap's `sticky-top` class that applies the following:

```css
@supports (position: sticky) {
    .sticky-top {
        position: sticky;
        top: 0;
        z-index: 1020;
    }
}
```

There are a few ways we could go about this.

1. Change the z-index of the `sticky-top` class from Bootstrap, that we use for both sidebars.
2. Add styles for `[data-ea-style=stickybox].loaded`. This seems brittle.
3. Use our own CSS to apply the stickiness. For example, with the following CSS:
   ```css
   .sticky {
     position: sticky;
     top: 0;
     z-index: 20;
   }
   ```
   And then use it in the following places: https://github.com/wagtail/sphinx-wagtail-theme/blob/25ccf6408139f9db09486c780ec86c1455f20d62/sphinx_wagtail_theme/layout.html#L114 https://github.com/wagtail/sphinx-wagtail-theme/blob/25ccf6408139f9db09486c780ec86c1455f20d62/sphinx_wagtail_theme/layout.html#L156


This PR uses approach 1. I changed all of the z-index values and not just the sticky one, because [Bootstrap's docs](https://getbootstrap.com/docs/4.6/layout/overview/#z-index) says the following:
   > We don’t encourage customization of these individual values; should you change one, you likely need to change them all.

I'm not sure of the implications this may have though, but from what I can tell our theme doesn't use dropdowns, `fixed`, modals, popovers, or tooltips.