### PR TITLE
Resolved  / #297

### DIFF
--- a/sass/_component_toc.scss
+++ b/sass/_component_toc.scss
@@ -57,18 +57,20 @@
     }
   }
 
-  .current > a {
-    color: theme-color('primary');
-
-    > .toctree-expand {
-      background-color: theme-color('primary');
-      color: color-yiq(theme-color('primary'));
-
-      &:before {
-        display: none;
+    .current > {
+      a {
+        color: theme-color('primary');
+      }
+  
+      .toctree-expand {
+        background-color: theme-color('primary');
+        color: color-yiq(theme-color('primary'));
+  
+        &:before {
+          display: none;
+        }
       }
     }
-  }
 
   > ul {
     padding-left: 0;


### PR DESCRIPTION
Resolves: #297 

The issue was caused by interpreting the element with the `.toctree-expand` class as a direct child of the `<a>` tag, when both are actually direct child of the element with the `.current` class in our use case.



https://github.com/user-attachments/assets/ea4167dd-7afe-4e78-804c-5f58e4086c2c

