### PR TITLE
Toasts and search

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,9 @@
 {
   "root": true,
   "extends": ["@wagtail/eslint-config-wagtail"],
+  "parserOptions": {
+    "ecmaVersion": 2022
+  },
   "env": { "browser": true },
   "globals": {
     "DOCUMENTATION_OPTIONS": "readonly",

--- a/js/theme.js
+++ b/js/theme.js
@@ -66,7 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Sphinx compatibility.
   // Prior to Sphinx 7.2, URL_ROOT was part of DOCUMENTATION_OPTIONS.
-  let URL_ROOT = "";
+  let URL_ROOT = '';
   // Sphinx >= 7.2
   if (document.documentElement.dataset.content_root) {
     URL_ROOT = document.documentElement.dataset.content_root;
@@ -155,4 +155,13 @@ document.addEventListener('DOMContentLoaded', () => {
       },
     });
   }
+});
+
+document.addEventListener('readthedocs-addons-data-ready', () => {
+  // Trigger the Read the Docs Addons Search modal when clicking on "Search docs" input from the topnav.
+  document
+    .querySelector("[role='search'] input")
+    ?.addEventListener('focusin', () => {
+      document.dispatchEvent(new CustomEvent('readthedocs-search-show'));
+    });
 });

--- a/sass/theme.scss
+++ b/sass/theme.scss
@@ -7,7 +7,46 @@
 // dependencies
 @import '../node_modules/@fortawesome/fontawesome-free/scss/mixins';
 @import '../node_modules/@fortawesome/fontawesome-free/scss/variables';
-@import '../node_modules/bootstrap/scss/bootstrap';
+// Bootstrap, minus the components we don’t use.
+@import '../node_modules/bootstrap/scss/functions';
+@import '../node_modules/bootstrap/scss/variables';
+@import '../node_modules/bootstrap/scss/mixins';
+@import '../node_modules/bootstrap/scss/root';
+@import '../node_modules/bootstrap/scss/reboot';
+@import '../node_modules/bootstrap/scss/type';
+@import '../node_modules/bootstrap/scss/images';
+@import '../node_modules/bootstrap/scss/code';
+@import '../node_modules/bootstrap/scss/grid';
+@import '../node_modules/bootstrap/scss/tables';
+@import '../node_modules/bootstrap/scss/forms';
+@import '../node_modules/bootstrap/scss/buttons';
+@import '../node_modules/bootstrap/scss/transitions';
+@import '../node_modules/bootstrap/scss/dropdown';
+@import '../node_modules/bootstrap/scss/button-group';
+@import '../node_modules/bootstrap/scss/input-group';
+@import '../node_modules/bootstrap/scss/custom-forms';
+@import '../node_modules/bootstrap/scss/nav';
+@import '../node_modules/bootstrap/scss/navbar';
+@import '../node_modules/bootstrap/scss/card';
+@import '../node_modules/bootstrap/scss/breadcrumb';
+@import '../node_modules/bootstrap/scss/pagination';
+@import '../node_modules/bootstrap/scss/badge';
+@import '../node_modules/bootstrap/scss/jumbotron';
+@import '../node_modules/bootstrap/scss/alert';
+@import '../node_modules/bootstrap/scss/progress';
+@import '../node_modules/bootstrap/scss/media';
+@import '../node_modules/bootstrap/scss/list-group';
+@import '../node_modules/bootstrap/scss/close';
+// Read the Docs Addons compatibility issue.
+// See https://github.com/readthedocs/addons/issues/413.
+// @import '../node_modules/bootstrap/scss/toasts';
+@import '../node_modules/bootstrap/scss/modal';
+@import '../node_modules/bootstrap/scss/tooltip';
+@import '../node_modules/bootstrap/scss/popover';
+@import '../node_modules/bootstrap/scss/carousel';
+@import '../node_modules/bootstrap/scss/spinners';
+@import '../node_modules/bootstrap/scss/utilities';
+@import '../node_modules/bootstrap/scss/print';
 
 // components
 @import 'component_admotion';


### PR DESCRIPTION
Fixes one issue and implements one feature:

- Removes Bootstrap toast styles, which interfere with the Read the Docs Addons’ "readthedocs-notification" component, which also uses the `toast` class. We don’t need this part of Bootstrap so might as well remove it.
- Triggers the Read the Docs Addons’ search modal, if RTD Addons are initialised on the page.

Both of those issues are impossible to properly test locally but can be checked with the [PR preview build](https://sphinx-wagtail-theme--299.org.readthedocs.build/en/299/).