### PR TITLE
Fix color of theme and Sphinx links in footer in light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [6.5.0] - Unreleased
+
+### Added
+
+-   ...
+
+### Changed
+
+-   ...
+
+### Removed
+
+-   ...
+
+### Fixed
+
+-   ...
+
+### Security
+
+-   ...
+
 ## [6.4.0] - 2024-11-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
--   ...
+-   Fix color of theme and Sphinx links in footer in light mode (Sage Abdullah)
 
 ### Security
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sphinx_wagtail_theme
-version = 6.4.0
+version = 6.5.0.dev0
 author = Coen van der Kamp
 author_email = coen@fourdigits.nl
 description = Sphinx Wagtail theme

--- a/sphinx_wagtail_theme/footer.html
+++ b/sphinx_wagtail_theme/footer.html
@@ -31,11 +31,11 @@
                 {%- if show_sphinx %}
                 <small>
                     Created using
-                    <a href="https://github.com/wagtail/sphinx_wagtail_theme" rel="nofollow" target="_blank">
+                    <a class="text-white" href="https://github.com/wagtail/sphinx_wagtail_theme" rel="nofollow" target="_blank">
                         Sphinx Wagtail Theme {{ theme_version|e }}
                     </a>
                     and
-                    <a href="https://www.sphinx-doc.org/" rel="nofollow" target="_blank">
+                    <a class="text-white" href="https://www.sphinx-doc.org/" rel="nofollow" target="_blank">
                         Sphinx {{ sphinx_version }}
                     </a>
                 </small>


### PR DESCRIPTION
Fixes #301.

I added `text-light` to the elements instead of updating the footer's CSS, because I couldn't find a way to use Bootstrap's `text-light` color in CSS to match the other links.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/caab82cf-d4f1-4479-a786-6849daa5a811">
