### PR TITLE
Remove inline scripts and styles from domainindex.html template.  Fix #305

### DIFF
--- a/sphinx_wagtail_theme/domainindex.html
+++ b/sphinx_wagtail_theme/domainindex.html
@@ -35,7 +35,7 @@
      <tr{% if grouptype == 2 %} class="cg-{{ groupid.current() }}"{% endif %}>
        <td>{% if grouptype == 1 -%}
          <img src="{{ pathto('_static/minus.png', 1) }}" class="toggler"
-              id="toggle-{{ groupid.next() }}" alt="-" />
+              id="toggle-{{ groupid.next() }}" alt="Toggle" />
            {%- endif %}</td>
        <td>{% if grouptype == 2 %}&#160;&#160;&#160;{% endif %}
        {% if page %}<a href="{{ pathto(page) }}#{{ anchor }}">{% endif -%}

--- a/sphinx_wagtail_theme/domainindex.html
+++ b/sphinx_wagtail_theme/domainindex.html
@@ -11,11 +11,6 @@
 {% set title = indextitle %}
 {% block extrahead %}
 {{ super() }}
-{% if not embedded and collapse_index %}
-    <script>
-      DOCUMENTATION_OPTIONS.COLLAPSE_INDEX = true;
-    </script>
-{% endif %}
 {% endblock %}
 {% block body %}
 
@@ -40,7 +35,7 @@
      <tr{% if grouptype == 2 %} class="cg-{{ groupid.current() }}"{% endif %}>
        <td>{% if grouptype == 1 -%}
          <img src="{{ pathto('_static/minus.png', 1) }}" class="toggler"
-              id="toggle-{{ groupid.next() }}" style="display: none" alt="-" />
+              id="toggle-{{ groupid.next() }}" alt="-" />
            {%- endif %}</td>
        <td>{% if grouptype == 2 %}&#160;&#160;&#160;{% endif %}
        {% if page %}<a href="{{ pathto(page) }}#{{ anchor }}">{% endif -%}


### PR DESCRIPTION
This is a built-in feature of Sphinx which Wagtail doesn’t really use. https://docs.wagtail.org/en/latest/py-modindex.html

- Inline styles aren’t needed as we probably want the section to be open by default
- Same for inline script
- Fix alt text while we’re at it

If we wanted to support collapsed sections, then this needs a lot of rework so the toggle element isn’t an image (accessibility fail, no keyboard support).